### PR TITLE
Default pick for dropdown word record in backend

### DIFF
--- a/backend/src/main/java/com/github/mysterix5/vover/model/primary/PrimaryResponseDTO.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/model/primary/PrimaryResponseDTO.java
@@ -15,4 +15,5 @@ import java.util.Map;
 public class PrimaryResponseDTO {
     private List<RecordResponseDTO> textWords;
     private Map<String, List<RecordDbResponseDTO>> wordRecordMap;
+    private List<String> defaultIds;
 }

--- a/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
@@ -34,6 +34,7 @@ public class PrimaryService {
         wordList = wordList.stream().map(String::toLowerCase).toList();
         Set<String> appearingWordsSet = wordList.stream().filter(this::wordValidCheck).collect(Collectors.toSet());
         Map<String, List<RecordDbResponseDTO>> dbWordsMap = createDbWordsMap(appearingWordsSet, username);
+        List<String> defaultIds = new ArrayList<>();
 
         List<RecordResponseDTO> textWordsResponse = wordList.stream()
                 .map(RecordResponseDTO::new)
@@ -41,15 +42,18 @@ public class PrimaryService {
                     if (appearingWordsSet.contains(w.getWord())) {
                         if (dbWordsMap.containsKey(w.getWord())) {
                             w.setAvailability(Availability.PUBLIC);
+                            defaultIds.add(dbWordsMap.get(w.getWord()).get(0).getId());
                         } else {
                             w.setAvailability(Availability.NOT_AVAILABLE);
+                            defaultIds.add(null);
                         }
                     } else {
                         w.setAvailability(Availability.INVALID);
+                        defaultIds.add(null);
                     }
                 }).toList();
 
-        return new PrimaryResponseDTO(textWordsResponse, dbWordsMap);
+        return new PrimaryResponseDTO(textWordsResponse, dbWordsMap, defaultIds);
     }
 
 

--- a/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
+++ b/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
@@ -42,7 +42,8 @@ class PrimaryServiceTest {
         PrimaryResponseDTO expected = new PrimaryResponseDTO(
                 List.of(new RecordResponseDTO("bester", Availability.PUBLIC), new RecordResponseDTO("test", Availability.PUBLIC)),
                 Map.of("bester", List.of(new RecordDbResponseDTO(recordDbEntity1)),
-                        "test", List.of(new RecordDbResponseDTO(recordDbEntity2))));
+                        "test", List.of(new RecordDbResponseDTO(recordDbEntity2))),
+                List.of("id1","id2"));
 
         assertThat(response).isEqualTo(expected);
     }
@@ -62,6 +63,12 @@ class PrimaryServiceTest {
 
         var response = primaryService.onSubmittedText(testString, "user");
 
+        List<String> defaultIds = new ArrayList<>();
+        defaultIds.add(null);
+        defaultIds.add("id1");
+        defaultIds.add(null);
+        defaultIds.add(null);
+
         var expected = new PrimaryResponseDTO(
                 List.of(
                         new RecordResponseDTO("beste/r", Availability.INVALID),
@@ -71,7 +78,8 @@ class PrimaryServiceTest {
                 ),
                 Map.of(
                         "test", List.of(new RecordDbResponseDTO(recordDbEntity1))
-                ));
+                ),
+                defaultIds);
 
         assertThat(response).isEqualTo(expected);
     }

--- a/frontend/src/pages/primary/TextCheck.tsx
+++ b/frontend/src/pages/primary/TextCheck.tsx
@@ -7,17 +7,14 @@ import WordDropdown from "../userpage/WordDropdown";
 
 interface TextCheckProps {
     textMetadataResponse: TextMetadataResponse,
-    ids: string[],
-    setIds: (ids: string[]) => void
+    setId: (id: string, index: number) => void
 }
 
 export default function TextCheck(props: TextCheckProps) {
 
     function generateIdSetter(index: number){
         return (id: string) => {
-            let localIds = props.ids;
-            localIds[index] = id;
-            props.setIds(localIds);
+            props.setId(id, index);
         }
     }
 
@@ -36,7 +33,7 @@ export default function TextCheck(props: TextCheckProps) {
 
         return (
             <Box sx={{backgroundColor: myColor}}>
-                <WordDropdown wordAvail={word} setIdInArray={generateIdSetter(index)} choicesList={props.textMetadataResponse.wordRecordMap[word.word]} id={props.ids[index]}/>
+                <WordDropdown wordAvail={word} setId={generateIdSetter(index)} choicesList={props.textMetadataResponse.wordRecordMap[word.word]} id={props.textMetadataResponse.defaultIds[index]}/>
             </Box>
         )
     }

--- a/frontend/src/pages/primary/TextSubmit.tsx
+++ b/frontend/src/pages/primary/TextSubmit.tsx
@@ -5,8 +5,7 @@ import {TextMetadataResponse} from "../../services/model";
 import {useAuth} from "../../usermanagement/AuthProvider";
 
 interface TextSubmitProps{
-    setTextMetadataResponse: (textResponse: TextMetadataResponse)=>void,
-    setIds: (ids: string[])=>void
+    setTextMetadataResponse: (textResponse: TextMetadataResponse)=>void
 }
 
 export default function TextSubmit(props: TextSubmitProps){
@@ -22,20 +21,7 @@ export default function TextSubmit(props: TextSubmitProps){
                 console.log(r);
                 props.setTextMetadataResponse(r);
                 return r;
-            })
-            .then(textResponse => {
-                const ids: string[] = [];
-                for(const word of textResponse.textWords){
-                    const mdl = textResponse.wordRecordMap[word.word];
-                    if(mdl && mdl.length>0){
-                        ids.push(mdl.at(0)!.id);
-                    }else{
-                        ids.push('');
-                    }
-                }
-                props.setIds(ids);
-            })
-        ;
+            });
     }
 
     return (

--- a/frontend/src/pages/primary/index.tsx
+++ b/frontend/src/pages/primary/index.tsx
@@ -11,9 +11,12 @@ import {useNavigate} from "react-router-dom";
 
 
 export default function Primary() {
-    const [textMetadataResponse, setTextMetadataResponse] = useState<TextMetadataResponse>();
+    const [textMetadataResponse, setTextMetadataResponse] = useState<TextMetadataResponse>({
+        textWords: [],
+        defaultIds: [],
+        wordRecordMap: {}
+    });
     const [audioFile, setAudioFile] = useState<any>();
-    const [ids, setIds] = useState<string[]>([])
 
     const {username, getToken, setError} = useAuth();
     const nav = useNavigate();
@@ -24,7 +27,7 @@ export default function Primary() {
         }
     }, [username, nav])
 
-    function handleTextMetadataResponse(textMetadataResponse: TextMetadataResponse){
+    function handleTextMetadataResponse(textMetadataResponse: TextMetadataResponse) {
         setTextMetadataResponse(textMetadataResponse);
         setAudioFile(null);
     }
@@ -39,7 +42,7 @@ export default function Primary() {
     }
 
     function getAudio() {
-        apiGetMergedAudio(getToken(), ids)
+        apiGetMergedAudio(getToken(), textMetadataResponse?.defaultIds!)
             .then(setAudioFile)
             .catch((err) => {
                 if (err.response) {
@@ -50,16 +53,21 @@ export default function Primary() {
             });
     }
 
+    function setId(id: string, index: number) {
+        let tmp = {...textMetadataResponse};
+        tmp.defaultIds[index] = id
+        setTextMetadataResponse(tmp);
+    }
 
     return (
         <Grid container alignItems={"center"} flexDirection={"column"}>
             <Grid item>
-                <TextSubmit setTextMetadataResponse={handleTextMetadataResponse} setIds={setIds}/>
+                <TextSubmit setTextMetadataResponse={handleTextMetadataResponse}/>
             </Grid>
             <Grid item ml={2} mr={2}>
                 {
                     textMetadataResponse &&
-                    <TextCheck textMetadataResponse={textMetadataResponse} ids={ids} setIds={setIds}/>
+                    <TextCheck textMetadataResponse={textMetadataResponse} setId={setId}/>
                 }
             </Grid>
             <Grid item>

--- a/frontend/src/pages/userpage/WordDropdown.tsx
+++ b/frontend/src/pages/userpage/WordDropdown.tsx
@@ -24,7 +24,16 @@ export default function WordDropdown(props: WordDropdownProps) {
     return (
         <FormControl variant="filled" size="small">
             <InputLabel id="demo-simple-select-label">
-                {props.wordAvail.word.toUpperCase()}
+                <Grid container direction={"row"} wrap={"nowrap"}>
+                    { props.choicesList && props.choicesList.length > 1 &&
+                        <Grid item mr={1} border={1}  bgcolor={"darkgrey"} color={"#577ee0"}>
+                            {props.choicesList.length}
+                        </Grid>
+                    }
+                    <Grid item>
+                        {props.wordAvail.word.toUpperCase()}
+                    </Grid>
+                </Grid>
             </InputLabel>
             <Select
                 size={"medium"}

--- a/frontend/src/pages/userpage/WordDropdown.tsx
+++ b/frontend/src/pages/userpage/WordDropdown.tsx
@@ -6,7 +6,7 @@ import {useEffect, useState} from "react";
 
 interface WordDropdownProps {
     wordAvail: WordAvail,
-    setIdInArray: (id: string) => void
+    setId: (id: string) => void
     choicesList: RecordMetaData[],
     id: string
 }
@@ -16,8 +16,8 @@ export default function WordDropdown(props: WordDropdownProps) {
     const [id, setId] = useState(props.id);
 
     useEffect(() => {
-        props.setIdInArray(id);
-    }, [id, props, props.setIdInArray])
+        props.setId(id);
+    }, [id, props, props.setId])
 
     const nav = useNavigate();
 

--- a/frontend/src/services/model.ts
+++ b/frontend/src/services/model.ts
@@ -21,7 +21,8 @@ export interface WordAvail {
 
 export interface TextMetadataResponse {
     textWords: WordAvail[],
-    wordRecordMap: WordRecordMap
+    wordRecordMap: WordRecordMap,
+    defaultIds: string[]
 }
 
 export interface AuthInterface {

--- a/frontend/src/usermanagement/AuthProvider.tsx
+++ b/frontend/src/usermanagement/AuthProvider.tsx
@@ -41,6 +41,7 @@ export default function AuthProvider({children}:{children :ReactNode}) {
     const getToken = () => {
         if((expired - (Math.floor(Date.now() / 1000)))<0){
             logout();
+            setError({message: "Your login token expired", subMessages: ["you need to login again"]})
             return '';
         }
         return token;


### PR DESCRIPTION
For the word dropdowns are default values necessary and these may later include some logic to choose interesting ones so they should be chosen in backend and not in frontend as before. 

- return an array of default ids for the word dropdowns from backend on PrimaryResponseDTO
- set those values in frontend as the default for the dropdowns
- adjust the setting of new ids on dropdown select in frontend with the new structure
- little display feature: show how many choices there are hidden on dropdown menu
- show an error message when automatically logged out because token expired. closes #73 

hopefully closes #66 