### PR TITLE
Restructure history to save choices

### DIFF
--- a/backend/src/main/java/com/github/mysterix5/vover/history/HistoryMongoRepository.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/history/HistoryMongoRepository.java
@@ -1,0 +1,12 @@
+package com.github.mysterix5.vover.history;
+
+import com.github.mysterix5.vover.model.user_details.HistoryEntry;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HistoryMongoRepository  extends MongoRepository<HistoryEntry, String> {
+    List<HistoryEntry> findAllByIdIn(List<String> historyIds);
+}

--- a/backend/src/main/java/com/github/mysterix5/vover/history/HistoryService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/history/HistoryService.java
@@ -1,0 +1,20 @@
+package com.github.mysterix5.vover.history;
+
+import com.github.mysterix5.vover.model.user_details.HistoryEntry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+    private final HistoryMongoRepository historyRepository;
+    public HistoryEntry save(HistoryEntry historyEntry){
+        return historyRepository.save(historyEntry);
+    }
+
+    public List<HistoryEntry> getAllByIds(List<String> historyIds) {
+        return historyRepository.findAllByIdIn(historyIds);
+    }
+}

--- a/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
@@ -1,15 +1,23 @@
 package com.github.mysterix5.vover.model.user_details;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Document(collection = "history")
 public class HistoryEntry {
+    @Id
+    private String id;
     private String text;
+    private List<String> choices;
     private LocalDateTime requestTime;
 }

--- a/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
@@ -1,7 +1,6 @@
 package com.github.mysterix5.vover.model.user_details;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;

--- a/backend/src/main/java/com/github/mysterix5/vover/model/user_details/VoverUserDetails.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/model/user_details/VoverUserDetails.java
@@ -13,7 +13,7 @@ public class VoverUserDetails {
     @Id
     private String username;
     private List<String> friends = new ArrayList<>();
-    private List<HistoryEntry> history = new ArrayList<>();
+    private List<String> history = new ArrayList<>();
 
     public VoverUserDetails(String username) {
         this.username = username;

--- a/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
@@ -109,8 +109,7 @@ public class PrimaryService {
                                     .filter(wordDb -> Objects.equals(wordDb.getId(), id))
                                     .findFirst()
                                     .orElseThrow()
-                                    .getWord())
-                            .toList()
+                            ).toList()
             );
             return merged;
         } catch (Exception e) {

--- a/backend/src/main/java/com/github/mysterix5/vover/records/RecordMongoRepository.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/records/RecordMongoRepository.java
@@ -4,10 +4,12 @@ import com.github.mysterix5.vover.model.record.RecordDbEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Set;
 
+@Repository
 public interface RecordMongoRepository extends MongoRepository<RecordDbEntity, String> {
     List<RecordDbEntity> findByWordIn(Set<String> words);
 

--- a/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsMongoRepository.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsMongoRepository.java
@@ -2,7 +2,9 @@ package com.github.mysterix5.vover.user_details;
 
 import com.github.mysterix5.vover.model.user_details.VoverUserDetails;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface VoverUserDetailsMongoRepository extends MongoRepository<VoverUserDetails, String> {
 
 }

--- a/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsService.java
@@ -1,5 +1,7 @@
 package com.github.mysterix5.vover.user_details;
 
+import com.github.mysterix5.vover.history.HistoryService;
+import com.github.mysterix5.vover.model.record.RecordDbEntity;
 import com.github.mysterix5.vover.model.user_details.HistoryEntry;
 import com.github.mysterix5.vover.model.user_details.VoverUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -14,18 +16,33 @@ import java.util.List;
 @RequiredArgsConstructor
 public class VoverUserDetailsService {
     private final VoverUserDetailsMongoRepository userDetailsRepository;
+    private final HistoryService historyService;
 
-    public void addRequestToHistory(String username, List<String> wordList) {
-        String text = String.join(" ", wordList);
-        HistoryEntry historyEntry = new HistoryEntry(text, LocalDateTime.now());
+    public void addRequestToHistory(String username, List<RecordDbEntity> recordList) {
+        String text = String.join(" ",
+                recordList.stream()
+                        .map(RecordDbEntity::getWord)
+                        .toList()
+                );
+        List<String> ids = recordList.stream()
+                .map(RecordDbEntity::getId)
+                .toList();
+        HistoryEntry historyEntry = new HistoryEntry();
+        historyEntry.setText(text);
+        historyEntry.setChoices(ids);
+        historyEntry.setRequestTime(LocalDateTime.now());
+
+        historyEntry = historyService.save(historyEntry);
+
         VoverUserDetails voverUserDetails = getUserDetails(username);
-        voverUserDetails.getHistory().add(historyEntry);
+        voverUserDetails.getHistory().add(historyEntry.getId());
         userDetailsRepository.save(voverUserDetails);
         log.info("text '{}' is added to history of user '{}'", text, username);
     }
 
     public List<HistoryEntry> getHistory(String username) {
-        return getUserDetails(username).getHistory();
+        List<String> historyIds = getUserDetails(username).getHistory();
+        return historyService.getAllByIds(historyIds);
     }
 
     private VoverUserDetails getUserDetails(String username) {

--- a/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
+++ b/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
@@ -130,7 +130,7 @@ class PrimaryServiceTest {
 
             byte[] mergedAudio = primaryService.getMergedAudio(List.of("id1", "id2"), "creator1");
 
-            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of("eins", "zwei"));
+//            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of(recordDbEntity1, recordDbEntity2));
             assertThat(mergedAudio.length).isEqualTo(einsZweiStream.readAllBytes().length);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
+++ b/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
@@ -130,7 +130,7 @@ class PrimaryServiceTest {
 
             byte[] mergedAudio = primaryService.getMergedAudio(List.of("id1", "id2"), "creator1");
 
-//            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of(recordDbEntity1, recordDbEntity2));
+            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of(recordDbEntity1, recordDbEntity2));
             assertThat(mergedAudio.length).isEqualTo(einsZweiStream.readAllBytes().length);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/backend/src/test/java/com/github/mysterix5/vover/user_details/VoverUserDetailsServiceTest.java
+++ b/backend/src/test/java/com/github/mysterix5/vover/user_details/VoverUserDetailsServiceTest.java
@@ -1,8 +1,11 @@
 package com.github.mysterix5.vover.user_details;
 
+import com.github.mysterix5.vover.history.HistoryService;
+import com.github.mysterix5.vover.model.record.RecordDbEntity;
 import com.github.mysterix5.vover.model.user_details.HistoryEntry;
 import com.github.mysterix5.vover.model.user_details.VoverUserDetails;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
@@ -16,36 +19,58 @@ class VoverUserDetailsServiceTest {
     @Test
     void addRequestToHistory() {
         VoverUserDetailsMongoRepository mockedUserDetailsRepository = Mockito.mock(VoverUserDetailsMongoRepository.class);
-        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository);
+        HistoryService mockedHistoryService = Mockito.mock(HistoryService.class);
+        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository, mockedHistoryService);
 
         String username = "user";
-        List<String> words = List.of("ein", "kleiner", "test");
+        List<RecordDbEntity> records = List.of(
+                RecordDbEntity.builder().word("ein").id("id1").build(),
+                RecordDbEntity.builder().word("kleiner").id("id2").build(),
+                RecordDbEntity.builder().word("test").id("id3").build()
+        );
 
         VoverUserDetails testUserDetails = new VoverUserDetails(username);
 
         Mockito.when(mockedUserDetailsRepository.findById(username)).thenReturn(Optional.of(testUserDetails));
 
-        voverUserDetailsService.addRequestToHistory(username, words);
+        try (MockedStatic<LocalDateTime> mb = Mockito.mockStatic(LocalDateTime.class)) {
+            var time = LocalDateTime.now();
+            mb.when(LocalDateTime::now).thenReturn(time);
 
-        var expected = new VoverUserDetails(username);
-        expected.getHistory().add(new HistoryEntry("ein kleiner test", testUserDetails.getHistory().get(0).getRequestTime()));
+            HistoryEntry historyEntry = new HistoryEntry(null, "ein kleiner test", List.of("id1", "id2", "id3"), time);
+            HistoryEntry historyEntryReturnFromSave = new HistoryEntry("dummyid", "ein kleiner test", List.of("id1", "id2", "id3"), time);
+            Mockito.when(mockedHistoryService.save(historyEntry)).thenReturn(historyEntryReturnFromSave);
 
-        Mockito.verify(mockedUserDetailsRepository).save(expected);
+            voverUserDetailsService.addRequestToHistory(username, records);
+
+            var expected = new VoverUserDetails(username);
+            expected.getHistory().add("dummyid");
+
+            Mockito.verify(mockedUserDetailsRepository).save(expected);
+
+        }
     }
 
     @Test
     void getHistory() {
         VoverUserDetailsMongoRepository mockedUserDetailsRepository = Mockito.mock(VoverUserDetailsMongoRepository.class);
-        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository);
+        HistoryService mockedHistoryService = Mockito.mock(HistoryService.class);
+        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository, mockedHistoryService);
 
         String username = "user";
         List<String> words = List.of("ein", "kleiner", "test");
-        List<HistoryEntry> history = List.of(new HistoryEntry(String.join(" ", words), LocalDateTime.now()));
+        List<HistoryEntry> history = List.of(new HistoryEntry(
+                "testid",
+                "ein kleiner test",
+                List.of("1", "2", "3"),
+                LocalDateTime.now())
+        );
 
         VoverUserDetails testUserDetails = new VoverUserDetails(username);
-        testUserDetails.setHistory(history);
+        testUserDetails.setHistory(List.of("testid"));
 
         Mockito.when(mockedUserDetailsRepository.findById(username)).thenReturn(Optional.of(testUserDetails));
+        Mockito.when(mockedHistoryService.getAllByIds(List.of("testid"))).thenReturn(history);
 
         List<HistoryEntry> actual = voverUserDetailsService.getHistory(username);
 


### PR DESCRIPTION
- HistoryEntries are now saved in their own MongoDB collection and UserDetails has only a list of ids
- Main site can be called with history id and then text and record choices are prefilled
- these urls with id can be shared
- closes #104 
- closes #103 