### PR TITLE
history elements can be used to get to same audio again

### DIFF
--- a/backend/src/main/java/com/github/mysterix5/vover/history/HistoryController.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/history/HistoryController.java
@@ -1,0 +1,21 @@
+package com.github.mysterix5.vover.history;
+
+import com.github.mysterix5.vover.model.user_details.HistoryEntry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/history")
+public class HistoryController {
+    private final HistoryService historyService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<HistoryEntry> getHistoryEntryForPrimary(@PathVariable String id){
+        return ResponseEntity.ok(historyService.getById(id));
+    }
+}

--- a/backend/src/main/java/com/github/mysterix5/vover/history/HistoryMongoRepository.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/history/HistoryMongoRepository.java
@@ -1,0 +1,12 @@
+package com.github.mysterix5.vover.history;
+
+import com.github.mysterix5.vover.model.user_details.HistoryEntry;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HistoryMongoRepository  extends MongoRepository<HistoryEntry, String> {
+    List<HistoryEntry> findAllByIdIn(List<String> historyIds);
+}

--- a/backend/src/main/java/com/github/mysterix5/vover/history/HistoryService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/history/HistoryService.java
@@ -1,0 +1,20 @@
+package com.github.mysterix5.vover.history;
+
+import com.github.mysterix5.vover.model.user_details.HistoryEntry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+    private final HistoryMongoRepository historyRepository;
+    public HistoryEntry save(HistoryEntry historyEntry){
+        return historyRepository.save(historyEntry);
+    }
+
+    public List<HistoryEntry> getAllByIds(List<String> historyIds) {
+        return historyRepository.findAllByIdIn(historyIds);
+    }
+}

--- a/backend/src/main/java/com/github/mysterix5/vover/history/HistoryService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/history/HistoryService.java
@@ -14,6 +14,9 @@ public class HistoryService {
         return historyRepository.save(historyEntry);
     }
 
+    public HistoryEntry getById(String id){
+        return historyRepository.findById(id).orElseThrow();
+    }
     public List<HistoryEntry> getAllByIds(List<String> historyIds) {
         return historyRepository.findAllByIdIn(historyIds);
     }

--- a/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
@@ -1,15 +1,23 @@
 package com.github.mysterix5.vover.model.user_details;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Document(collection = "history")
 public class HistoryEntry {
+    @Id
+    private String id;
     private String text;
+    private List<String> choices;
     private LocalDateTime requestTime;
 }

--- a/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/model/user_details/HistoryEntry.java
@@ -1,7 +1,6 @@
 package com.github.mysterix5.vover.model.user_details;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;

--- a/backend/src/main/java/com/github/mysterix5/vover/model/user_details/VoverUserDetails.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/model/user_details/VoverUserDetails.java
@@ -13,7 +13,7 @@ public class VoverUserDetails {
     @Id
     private String username;
     private List<String> friends = new ArrayList<>();
-    private List<HistoryEntry> history = new ArrayList<>();
+    private List<String> history = new ArrayList<>();
 
     public VoverUserDetails(String username) {
         this.username = username;

--- a/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
@@ -109,8 +109,7 @@ public class PrimaryService {
                                     .filter(wordDb -> Objects.equals(wordDb.getId(), id))
                                     .findFirst()
                                     .orElseThrow()
-                                    .getWord())
-                            .toList()
+                            ).toList()
             );
             return merged;
         } catch (Exception e) {

--- a/backend/src/main/java/com/github/mysterix5/vover/records/RecordMongoRepository.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/records/RecordMongoRepository.java
@@ -4,10 +4,12 @@ import com.github.mysterix5.vover.model.record.RecordDbEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Set;
 
+@Repository
 public interface RecordMongoRepository extends MongoRepository<RecordDbEntity, String> {
     List<RecordDbEntity> findByWordIn(Set<String> words);
 

--- a/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsMongoRepository.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsMongoRepository.java
@@ -2,7 +2,9 @@ package com.github.mysterix5.vover.user_details;
 
 import com.github.mysterix5.vover.model.user_details.VoverUserDetails;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface VoverUserDetailsMongoRepository extends MongoRepository<VoverUserDetails, String> {
 
 }

--- a/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/user_details/VoverUserDetailsService.java
@@ -1,5 +1,7 @@
 package com.github.mysterix5.vover.user_details;
 
+import com.github.mysterix5.vover.history.HistoryService;
+import com.github.mysterix5.vover.model.record.RecordDbEntity;
 import com.github.mysterix5.vover.model.user_details.HistoryEntry;
 import com.github.mysterix5.vover.model.user_details.VoverUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -14,18 +16,33 @@ import java.util.List;
 @RequiredArgsConstructor
 public class VoverUserDetailsService {
     private final VoverUserDetailsMongoRepository userDetailsRepository;
+    private final HistoryService historyService;
 
-    public void addRequestToHistory(String username, List<String> wordList) {
-        String text = String.join(" ", wordList);
-        HistoryEntry historyEntry = new HistoryEntry(text, LocalDateTime.now());
+    public void addRequestToHistory(String username, List<RecordDbEntity> recordList) {
+        String text = String.join(" ",
+                recordList.stream()
+                        .map(RecordDbEntity::getWord)
+                        .toList()
+                );
+        List<String> ids = recordList.stream()
+                .map(RecordDbEntity::getId)
+                .toList();
+        HistoryEntry historyEntry = new HistoryEntry();
+        historyEntry.setText(text);
+        historyEntry.setChoices(ids);
+        historyEntry.setRequestTime(LocalDateTime.now());
+
+        historyEntry = historyService.save(historyEntry);
+
         VoverUserDetails voverUserDetails = getUserDetails(username);
-        voverUserDetails.getHistory().add(historyEntry);
+        voverUserDetails.getHistory().add(historyEntry.getId());
         userDetailsRepository.save(voverUserDetails);
         log.info("text '{}' is added to history of user '{}'", text, username);
     }
 
     public List<HistoryEntry> getHistory(String username) {
-        return getUserDetails(username).getHistory();
+        List<String> historyIds = getUserDetails(username).getHistory();
+        return historyService.getAllByIds(historyIds);
     }
 
     private VoverUserDetails getUserDetails(String username) {

--- a/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
+++ b/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
@@ -130,7 +130,7 @@ class PrimaryServiceTest {
 
             byte[] mergedAudio = primaryService.getMergedAudio(List.of("id1", "id2"), "creator1");
 
-            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of("eins", "zwei"));
+//            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of(recordDbEntity1, recordDbEntity2));
             assertThat(mergedAudio.length).isEqualTo(einsZweiStream.readAllBytes().length);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
+++ b/backend/src/test/java/com/github/mysterix5/vover/primary/PrimaryServiceTest.java
@@ -130,7 +130,7 @@ class PrimaryServiceTest {
 
             byte[] mergedAudio = primaryService.getMergedAudio(List.of("id1", "id2"), "creator1");
 
-//            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of(recordDbEntity1, recordDbEntity2));
+            Mockito.verify(mockedVoverUserDetailsService).addRequestToHistory("creator1", List.of(recordDbEntity1, recordDbEntity2));
             assertThat(mergedAudio.length).isEqualTo(einsZweiStream.readAllBytes().length);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/backend/src/test/java/com/github/mysterix5/vover/user_details/VoverUserDetailsServiceTest.java
+++ b/backend/src/test/java/com/github/mysterix5/vover/user_details/VoverUserDetailsServiceTest.java
@@ -1,8 +1,11 @@
 package com.github.mysterix5.vover.user_details;
 
+import com.github.mysterix5.vover.history.HistoryService;
+import com.github.mysterix5.vover.model.record.RecordDbEntity;
 import com.github.mysterix5.vover.model.user_details.HistoryEntry;
 import com.github.mysterix5.vover.model.user_details.VoverUserDetails;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
@@ -16,36 +19,58 @@ class VoverUserDetailsServiceTest {
     @Test
     void addRequestToHistory() {
         VoverUserDetailsMongoRepository mockedUserDetailsRepository = Mockito.mock(VoverUserDetailsMongoRepository.class);
-        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository);
+        HistoryService mockedHistoryService = Mockito.mock(HistoryService.class);
+        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository, mockedHistoryService);
 
         String username = "user";
-        List<String> words = List.of("ein", "kleiner", "test");
+        List<RecordDbEntity> records = List.of(
+                RecordDbEntity.builder().word("ein").id("id1").build(),
+                RecordDbEntity.builder().word("kleiner").id("id2").build(),
+                RecordDbEntity.builder().word("test").id("id3").build()
+        );
 
         VoverUserDetails testUserDetails = new VoverUserDetails(username);
 
         Mockito.when(mockedUserDetailsRepository.findById(username)).thenReturn(Optional.of(testUserDetails));
 
-        voverUserDetailsService.addRequestToHistory(username, words);
+        try (MockedStatic<LocalDateTime> mb = Mockito.mockStatic(LocalDateTime.class)) {
+            var time = LocalDateTime.now();
+            mb.when(LocalDateTime::now).thenReturn(time);
 
-        var expected = new VoverUserDetails(username);
-        expected.getHistory().add(new HistoryEntry("ein kleiner test", testUserDetails.getHistory().get(0).getRequestTime()));
+            HistoryEntry historyEntry = new HistoryEntry(null, "ein kleiner test", List.of("id1", "id2", "id3"), time);
+            HistoryEntry historyEntryReturnFromSave = new HistoryEntry("dummyid", "ein kleiner test", List.of("id1", "id2", "id3"), time);
+            Mockito.when(mockedHistoryService.save(historyEntry)).thenReturn(historyEntryReturnFromSave);
 
-        Mockito.verify(mockedUserDetailsRepository).save(expected);
+            voverUserDetailsService.addRequestToHistory(username, records);
+
+            var expected = new VoverUserDetails(username);
+            expected.getHistory().add("dummyid");
+
+            Mockito.verify(mockedUserDetailsRepository).save(expected);
+
+        }
     }
 
     @Test
     void getHistory() {
         VoverUserDetailsMongoRepository mockedUserDetailsRepository = Mockito.mock(VoverUserDetailsMongoRepository.class);
-        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository);
+        HistoryService mockedHistoryService = Mockito.mock(HistoryService.class);
+        VoverUserDetailsService voverUserDetailsService = new VoverUserDetailsService(mockedUserDetailsRepository, mockedHistoryService);
 
         String username = "user";
         List<String> words = List.of("ein", "kleiner", "test");
-        List<HistoryEntry> history = List.of(new HistoryEntry(String.join(" ", words), LocalDateTime.now()));
+        List<HistoryEntry> history = List.of(new HistoryEntry(
+                "testid",
+                "ein kleiner test",
+                List.of("1", "2", "3"),
+                LocalDateTime.now())
+        );
 
         VoverUserDetails testUserDetails = new VoverUserDetails(username);
-        testUserDetails.setHistory(history);
+        testUserDetails.setHistory(List.of("testid"));
 
         Mockito.when(mockedUserDetailsRepository.findById(username)).thenReturn(Optional.of(testUserDetails));
+        Mockito.when(mockedHistoryService.getAllByIds(List.of("testid"))).thenReturn(history);
 
         List<HistoryEntry> actual = voverUserDetailsService.getHistory(username);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ export default function App() {
                     <Header/>
                     <Routes>
                         <Route path="/" element={<Primary/>}/>
+                        <Route path="/x/:id" element={<Primary/>}/>
                         <Route path="/record" element={<Record/>}/>
                         <Route path="/login" element={<LoginPage/>}/>
                         <Route path="/register" element={<RegisterPage/>}/>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
                     <Header/>
                     <Routes>
                         <Route path="/" element={<Primary/>}/>
-                        <Route path="/x/:id" element={<Primary/>}/>
+                        <Route path="/h/:historyId" element={<Primary/>}/>
                         <Route path="/record" element={<Record/>}/>
                         <Route path="/login" element={<LoginPage/>}/>
                         <Route path="/register" element={<RegisterPage/>}/>

--- a/frontend/src/pages/primary/TextSubmit.tsx
+++ b/frontend/src/pages/primary/TextSubmit.tsx
@@ -1,27 +1,18 @@
 import {Box, Button, Grid, TextField} from "@mui/material";
-import {FormEvent, useState} from "react";
-import {apiSendTextToBackend} from "../../services/apiServices";
-import {TextMetadataResponse} from "../../services/model";
-import {useAuth} from "../../usermanagement/AuthProvider";
+import {FormEvent} from "react";
 
 interface TextSubmitProps{
-    setTextMetadataResponse: (textResponse: TextMetadataResponse)=>void
+    text: string,
+    setText: (s: string) => void,
+    submitText: ()=>void
 }
 
 export default function TextSubmit(props: TextSubmitProps){
 
-    const [text, setText] = useState("");
-    const {getToken} = useAuth();
-
     const sendTextToBackend = (event: FormEvent) => {
         event.preventDefault();
         console.log("send text to backend");
-        apiSendTextToBackend(getToken(), {text})
-            .then(r=>{
-                console.log(r);
-                props.setTextMetadataResponse(r);
-                return r;
-            });
+        props.submitText();
     }
 
     return (
@@ -33,10 +24,10 @@ export default function TextSubmit(props: TextSubmitProps){
                         label="text to audio"
                         multiline
                         rows={4}
-                        value={text}
+                        value={props.text}
                         margin={"normal"}
                         sx={{margin: 1}}
-                        onChange={event => setText(event.target.value)}
+                        onChange={event => props.setText(event.target.value)}
                     />
                 </Grid>
 

--- a/frontend/src/pages/primary/WordDropdown.tsx
+++ b/frontend/src/pages/primary/WordDropdown.tsx
@@ -1,8 +1,7 @@
-import {FormControl, Grid, InputLabel, MenuItem, Select, SelectChangeEvent, Typography} from "@mui/material";
+import {FormControl, Grid, InputLabel, MenuItem, Select, Typography} from "@mui/material";
 import {isAvailable} from "../../globalTools/helpers";
 import {WordAvail, RecordMetaData} from "../../services/model";
 import {useNavigate} from "react-router-dom";
-import {useEffect, useState} from "react";
 
 interface WordDropdownProps {
     wordAvail: WordAvail,
@@ -12,18 +11,6 @@ interface WordDropdownProps {
 }
 
 export default function WordDropdown(props: WordDropdownProps) {
-
-    const [id, setId] = useState(props.id);
-
-    const handleChange = (event: SelectChangeEvent) => {
-        if(id!==event.target.value){
-            setId(event.target.value);
-        }
-    };
-
-    useEffect(() => {
-        props.setId(id);
-    }, [id, props, props.setId])
 
     const nav = useNavigate();
 
@@ -47,10 +34,10 @@ export default function WordDropdown(props: WordDropdownProps) {
                 labelId="demo-simple-select-label"
                 id="demo-simple-select"
                 autoWidth
-                value={isAvailable(props.wordAvail.availability) ? id : 'record'}
+                value={isAvailable(props.wordAvail.availability) ? props.id : 'record'}
                 label={props.wordAvail.word.toUpperCase()}
                 IconComponent={() => null}
-                onChange={handleChange}
+                onChange={e=>props.setId(e.target.value)}
                 sx={{textAlign: "center"}}
             >
                 {isAvailable(props.wordAvail.availability) ?

--- a/frontend/src/pages/primary/index.tsx
+++ b/frontend/src/pages/primary/index.tsx
@@ -1,7 +1,7 @@
 import {Grid} from "@mui/material";
 import TextSubmit from "./TextSubmit";
-import {useCallback, useEffect, useState} from "react";
-import {TextMetadataResponse} from "../../services/model";
+import {useEffect, useState} from "react";
+import {RecordMetaData, TextMetadataResponse} from "../../services/model";
 import TextCheck from "./TextCheck";
 import Audio from "./Audio";
 import {apiGetHistoryEntryById, apiGetMergedAudio, apiSendTextToBackend} from "../../services/apiServices";
@@ -10,56 +10,89 @@ import {useAuth} from "../../usermanagement/AuthProvider";
 import {useNavigate, useParams} from "react-router-dom";
 
 
+const initialMetadataResponse = {
+    textWords: [],
+    defaultIds: [],
+    wordRecordMap: {}
+};
+
 export default function Primary() {
-    const [textMetadataResponse, setTextMetadataResponse] = useState<TextMetadataResponse>({
-        textWords: [],
-        defaultIds: [],
-        wordRecordMap: {}
-    });
+    const [textMetadataResponse, setTextMetadataResponse] = useState<TextMetadataResponse>(initialMetadataResponse);
     const [audioFile, setAudioFile] = useState<any>();
     const [text, setText] = useState("")
 
-    const {getToken, setError} = useAuth();
+    const {setError, defaultApiResponseChecks} = useAuth();
     const nav = useNavigate();
 
-    const {id} = useParams();
+    const {historyId} = useParams();
 
-    const fetchFromPathHistoryId = useCallback(()=>{
-        if(id){
-            console.log("have id in primary: "+ id);
-            apiGetHistoryEntryById(getToken(), id)
-                .then(h=>{
-                    console.log(h);
-                    setText(h.text);
-                    apiSendTextToBackend(getToken(), {text: h.text})
-                        .then(textMetadataResponse=>{
-                            setAudioFile(null);
-                            textMetadataResponse.defaultIds = h.choices;
-                            setTextMetadataResponse(textMetadataResponse);
-                        })
-                })
-            ;
+    function isIdInChoices(theId: string, theChoices: RecordMetaData[]) {
+        for (const recordMD of theChoices) {
+            if (theId === recordMD.id) {
+                return true
+            }
         }
-    }, [getToken, id])
-
-    useEffect(()=>{
-        fetchFromPathHistoryId();
-    }, [fetchFromPathHistoryId]);
+        return false;
+    }
 
     useEffect(() => {
-        if (!getToken()) {
+        if (historyId) {
+            console.log("have history id in primary: " + historyId);
+            apiGetHistoryEntryById(historyId)
+                .then(h => {
+                    console.log(h);
+                    setText(h.text);
+                    apiSendTextToBackend({text: h.text})
+                        .then(textMetadataResponseFromBackend => {
+                            setAudioFile(null);
+                            console.log(textMetadataResponseFromBackend);
+                            for (let i = 0; i < textMetadataResponseFromBackend.textWords.length; i++) {
+                                const choice = h.choices[i];
+                                const word = textMetadataResponseFromBackend.textWords[i];
+                                if (isAvailable(word.availability)) {
+                                    const actualWordChoices = textMetadataResponseFromBackend.wordRecordMap[word.word];
+                                    if (!isIdInChoices(choice, actualWordChoices)) {
+                                        textMetadataResponseFromBackend.defaultIds[i] = actualWordChoices[0].id;
+                                        console.log("change stuff")
+                                        setError({
+                                            message: "for some words the selected record is no longer available and was changed to default",
+                                            subMessages: []
+                                        });
+                                    } else {
+                                        textMetadataResponseFromBackend.defaultIds[i] = choice;
+                                    }
+                                } else {
+                                    textMetadataResponseFromBackend.defaultIds[i] = "";
+                                    setError({message: "for some words are no recordings available", subMessages: []});
+                                }
+                            }
+                            setTextMetadataResponse(textMetadataResponseFromBackend);
+                        }).catch(err => {
+                        defaultApiResponseChecks(err);
+                    });
+                }).catch(err => {
+                defaultApiResponseChecks(err);
+            });
+        }
+    }, [historyId, setError, defaultApiResponseChecks])
+
+    useEffect(() => {
+        if (!localStorage.getItem("jwt")) {
             nav("/login")
         }
-    }, [getToken, nav])
+    }, [nav])
 
-    function submitText(){
-        apiSendTextToBackend(getToken(), {text: text})
-            .then(r=>{
+    function submitText() {
+        apiSendTextToBackend({text: text})
+            .then(r => {
                 console.log(r);
                 setTextMetadataResponse(r);
                 setAudioFile(null);
                 return r;
-            });
+            }).catch(err => {
+                defaultApiResponseChecks(err);
+            }
+        );
     }
 
     function checkTextResponseAvailability() {
@@ -72,9 +105,10 @@ export default function Primary() {
     }
 
     function getAudio() {
-        apiGetMergedAudio(getToken(), textMetadataResponse?.defaultIds!)
+        apiGetMergedAudio(textMetadataResponse?.defaultIds!)
             .then(setAudioFile)
             .catch((err) => {
+                defaultApiResponseChecks(err);
                 if (err.response) {
                     const enc = new TextDecoder('utf-8')
                     const res = JSON.parse(enc.decode(new Uint8Array(err.response.data)))
@@ -83,12 +117,14 @@ export default function Primary() {
             });
     }
 
-    function setId(id: string, index: number) {
-        setTextMetadataResponse(current=>{
-            let tmp = {...current};
-            tmp.defaultIds[index] = id;
-            return tmp;
-        });
+    function setId(choiceId: string, index: number) {
+        if (textMetadataResponse.defaultIds[index] !== choiceId) {
+            setTextMetadataResponse(current => {
+                let tmp = {...current};
+                tmp.defaultIds[index] = choiceId;
+                return tmp;
+            });
+        }
     }
 
     return (

--- a/frontend/src/pages/primary/index.tsx
+++ b/frontend/src/pages/primary/index.tsx
@@ -1,6 +1,6 @@
 import {Grid} from "@mui/material";
 import TextSubmit from "./TextSubmit";
-import {useEffect, useState} from "react";
+import {useCallback, useEffect, useState} from "react";
 import {TextMetadataResponse} from "../../services/model";
 import TextCheck from "./TextCheck";
 import Audio from "./Audio";
@@ -24,7 +24,7 @@ export default function Primary() {
 
     const {id} = useParams();
 
-    useEffect(()=>{
+    const fetchFromPathHistoryId = useCallback(()=>{
         if(id){
             console.log("have id in primary: "+ id);
             apiGetHistoryEntryById(getToken(), id)
@@ -40,7 +40,11 @@ export default function Primary() {
                 })
             ;
         }
-    }, []);
+    }, [getToken, id])
+
+    useEffect(()=>{
+        fetchFromPathHistoryId();
+    }, [fetchFromPathHistoryId]);
 
     useEffect(() => {
         if (!getToken()) {

--- a/frontend/src/pages/record/index.tsx
+++ b/frontend/src/pages/record/index.tsx
@@ -20,7 +20,7 @@ export default function Record() {
     const [tag, setTag] = useState("normal");
     const [accessibility, setAccessibility] = useState("PUBLIC");
 
-    const {getToken, setError} = useAuth();
+    const {setError, defaultApiResponseChecks} = useAuth();
 
     const record = async () => {
         setIsLoading(true);
@@ -49,14 +49,15 @@ export default function Record() {
         event.preventDefault();
         console.log("save audio");
 
-        apiSaveAudio(getToken(), word, tag, accessibility, audioBlob!)
+        apiSaveAudio(word, tag, accessibility, audioBlob!)
             .then(() => {
                 setAudioLink("");
                 setAudioBlob(undefined);
                 setWord("");
-            }).catch((error) => {
-                if (error.response) {
-                    setError(error.response.data);
+            }).catch((err) => {
+                defaultApiResponseChecks(err);
+                if (err.response) {
+                    setError(err.response.data);
                 }
             });
     }

--- a/frontend/src/pages/userpage/History.tsx
+++ b/frontend/src/pages/userpage/History.tsx
@@ -1,15 +1,17 @@
 import {useEffect, useState} from "react";
 import {apiGetHistory} from "../../services/apiServices";
 import {useAuth} from "../../usermanagement/AuthProvider";
-import {HistoryEntry} from "../../services/model";
+import {HistoryEntryTextDate} from "../../services/model";
 import {Grid, Typography} from "@mui/material";
 import {formatDistance} from "date-fns";
+import {useNavigate} from "react-router-dom";
 
 
 export default function History() {
-    const [history, setHistory] = useState<HistoryEntry[]>([]);
+    const [history, setHistory] = useState<HistoryEntryTextDate[]>([]);
 
     const {getToken} = useAuth();
+    const nav = useNavigate();
 
     useEffect(() => {
         apiGetHistory(getToken())
@@ -24,7 +26,7 @@ export default function History() {
         <Grid container direction={"column"}>
             {
                 history?.map((h, i) =>
-                    <Grid item key={i} mb={0.5}>
+                    <Grid item key={i} mb={0.5} onClick={()=>nav(`/x/${h.id}`)}>
                         <Grid container direction={"row"} wrap={"nowrap"}>
                             <Grid item ml={1} mr={1} xs={4}>
                                 <Typography color={"lightgray"}>

--- a/frontend/src/pages/userpage/History.tsx
+++ b/frontend/src/pages/userpage/History.tsx
@@ -10,13 +10,17 @@ import {useNavigate} from "react-router-dom";
 export default function History() {
     const [history, setHistory] = useState<HistoryEntryTextDate[]>([]);
 
-    const {getToken} = useAuth();
     const nav = useNavigate();
 
+    const {defaultApiResponseChecks} = useAuth();
+
     useEffect(() => {
-        apiGetHistory(getToken())
-            .then(setHistory);
-    }, [getToken])
+        apiGetHistory()
+            .then(setHistory)
+            .catch(err=>{
+                defaultApiResponseChecks(err);
+            });
+    }, [defaultApiResponseChecks])
 
     function fancyStringFromDate(date: Date) {
         return formatDistance(date, new Date()) + " ago";
@@ -26,7 +30,7 @@ export default function History() {
         <Grid container direction={"column"}>
             {
                 history?.map((h, i) =>
-                    <Grid item key={i} mb={0.5} onClick={()=>nav(`/x/${h.id}`)}>
+                    <Grid item key={i} mb={0.5} onClick={()=>nav(`/h/${h.id}`)}>
                         <Grid container direction={"row"} wrap={"nowrap"}>
                             <Grid item ml={1} mr={1} xs={4}>
                                 <Typography color={"lightgray"}>

--- a/frontend/src/pages/userpage/RecordDetails.tsx
+++ b/frontend/src/pages/userpage/RecordDetails.tsx
@@ -12,7 +12,11 @@ import {
 import {RecordInfo} from "../../services/model";
 import {ChangeEvent, MouseEvent, useState} from "react";
 import {useAuth} from "../../usermanagement/AuthProvider";
-import {apiChangeRecord, apiDeleteRecord, apiGetSingleRecordedAudio} from "../../services/apiServices";
+import {
+    apiChangeRecord,
+    apiDeleteRecord,
+    apiGetSingleRecordedAudio
+} from "../../services/apiServices";
 import {AxiosError} from "axios";
 import CustomAudioPlayer from "../primary/CustomAudioPlayer";
 
@@ -31,7 +35,7 @@ export default function RecordDetails(props: RecordDetailsProps) {
 
     const [audioFile, setAudioFile] = useState<any>();
 
-    const {getToken, setError} = useAuth();
+    const {setError, defaultApiResponseChecks} = useAuth();
 
     const handleEditSwitch = (event: ChangeEvent<HTMLInputElement>) => {
         setEdit(event.target.checked);
@@ -45,20 +49,22 @@ export default function RecordDetails(props: RecordDetailsProps) {
     };
 
     function saveWord() {
-        apiChangeRecord(getToken(), {id: props.record.id, word: word, tag: tag, accessibility: accessibility})
+        apiChangeRecord({id: props.record.id, word: word, tag: tag, accessibility: accessibility})
             .then(props.getRecordPage)
             .then(() => setEdit(false))
-            .catch((error) => {
-                if (error.response) {
-                    setError(error.response.data);
+            .catch((err) => {
+                defaultApiResponseChecks(err);
+                if (err.response) {
+                    setError(err.response.data);
                 }
             });
     }
 
     function getAudio() {
-        apiGetSingleRecordedAudio(getToken(), props.record.id)
+        apiGetSingleRecordedAudio(props.record.id)
             .then(setAudioFile)
             .catch((err: AxiosError<ArrayBuffer>) => {
+                    defaultApiResponseChecks(err);
                     if (err.response) {
                         const enc = new TextDecoder('utf-8')
                         const res = JSON.parse(enc.decode(new Uint8Array(err.response.data)))
@@ -69,8 +75,11 @@ export default function RecordDetails(props: RecordDetailsProps) {
     }
 
     function deleteRecord() {
-        apiDeleteRecord(getToken(), props.record.id)
-            .then(props.getRecordPage);
+        apiDeleteRecord(props.record.id)
+            .then(props.getRecordPage)
+            .catch(err => {
+                defaultApiResponseChecks(err);
+            });
     }
 
     return (

--- a/frontend/src/pages/userpage/index.tsx
+++ b/frontend/src/pages/userpage/index.tsx
@@ -1,15 +1,24 @@
 import {Box, Grid, Tab, Typography} from "@mui/material";
 import Recordings from "./Recordings";
 import {TabContext, TabList, TabPanel} from "@mui/lab";
-import {SyntheticEvent, useState} from "react";
+import {SyntheticEvent, useEffect, useState} from "react";
 import History from "./History";
 import {useAuth} from "../../usermanagement/AuthProvider";
+import {useNavigate} from "react-router-dom";
 
 
 export default function UserPage() {
     const [tabValue, setTabValue] = useState("recordings");
 
     const {username} = useAuth();
+
+    const nav = useNavigate();
+
+    useEffect(() => {
+        if (!localStorage.getItem("jwt")) {
+            nav("/login")
+        }
+    }, [nav])
 
     const handleChange = (event: SyntheticEvent, newValue: string) => {
         setTabValue(newValue);

--- a/frontend/src/services/apiServices.ts
+++ b/frontend/src/services/apiServices.ts
@@ -1,5 +1,14 @@
 import axios, {AxiosResponse} from "axios";
-import {TextSend, TextMetadataResponse, LoginDTO, LoginResponse, RegisterDTO, RecordPage, RecordInfo} from "./model";
+import {
+    TextSend,
+    TextMetadataResponse,
+    LoginDTO,
+    LoginResponse,
+    RegisterDTO,
+    RecordPage,
+    RecordInfo,
+    HistoryEntryTextChoices
+} from "./model";
 
 function createHeaders(token: string) {
     return {
@@ -98,6 +107,14 @@ export function apiGetHistory(token: string){
         })
         ;
 }
+
+export function apiGetHistoryEntryById(token: string, id: string){
+    console.log(`get: /api/history/${id}`);
+    return axios.get(`/api/history/${id}`,
+        createHeaders(token)
+    ).then((response: AxiosResponse<HistoryEntryTextChoices>) => response.data);
+}
+
 
 // LocalDateTime from java has been converted to String for the request, this creates a js Date from it
 function parseISOString(s: string) {

--- a/frontend/src/services/apiServices.ts
+++ b/frontend/src/services/apiServices.ts
@@ -10,9 +10,9 @@ import {
     HistoryEntryTextChoices
 } from "./model";
 
-function createHeaders(token: string) {
+function createHeaders() {
     return {
-        headers: {Authorization: `Bearer ${token}`}
+        headers: {Authorization: `Bearer ${localStorage.getItem('jwt')}`}
     }
 }
 
@@ -26,29 +26,30 @@ export function sendLogin(user: LoginDTO) {
         .then((response: AxiosResponse<LoginResponse>) => response.data)
 }
 
-export function apiSendTextToBackend(token: string, text: TextSend) {
+
+export function apiSendTextToBackend(text: TextSend) {
     return axios.post("/api/primary",
         text,
-        createHeaders(token)
+        createHeaders()
     )
         .then((response: AxiosResponse<TextMetadataResponse>) => response.data);
 }
 
-export function apiGetMergedAudio(token: string, ids: string[]) {
+export function apiGetMergedAudio(ids: string[]) {
     return axios.post("/api/primary/audio",
         ids,
         {
-            headers: {Authorization: `Bearer ${token}`},
+            headers: {Authorization: `Bearer ${localStorage.getItem('jwt')}`},
             responseType: 'arraybuffer'
         })
         .then((response) => response.data)
         .then(data => window.URL.createObjectURL(new Blob([data])));
 }
 
-export function apiGetSingleRecordedAudio(token: string, id: string) {
+export function apiGetSingleRecordedAudio(id: string) {
     return axios.get(`/api/record/audio/${id}`,
         {
-            headers: {Authorization: `Bearer ${token}`},
+            headers: {Authorization: `Bearer ${localStorage.getItem('jwt')}`},
             responseType: 'arraybuffer'
         })
         .then((response) => response.data)
@@ -56,7 +57,7 @@ export function apiGetSingleRecordedAudio(token: string, id: string) {
 }
 
 
-export function apiSaveAudio(token: string, word: string, tag: string, accessibility: string, audioBlob: Blob) {
+export function apiSaveAudio(word: string, tag: string, accessibility: string, audioBlob: Blob) {
     const formData = new FormData();
 
     formData.append("word", word);
@@ -69,37 +70,39 @@ export function apiSaveAudio(token: string, word: string, tag: string, accessibi
         {
             headers: {
                 "Content-Type": "multipart/form-data",
-                Authorization: `Bearer ${token}`
+                Authorization: `Bearer ${localStorage.getItem('jwt')}`
             }
         }
     )
 }
 
-export function apiGetRecordPage(token: string, page: number, size: number, searchTerm: string) {
+export function apiGetRecordPage(page: number, size: number, searchTerm: string) {
     return axios.get(`/api/record/${page}/${size}?searchTerm=${searchTerm}`,
-        createHeaders(token)
+        createHeaders()
     )
         .then((response: AxiosResponse<RecordPage>) => response.data);
 }
 
-export function apiDeleteRecord(token: string, id: string) {
+export function apiDeleteRecord(id: string) {
     return axios.delete(`/api/record/${id}`,
-        createHeaders(token)
+        createHeaders()
     );
 }
-export function apiChangeRecord(token: string, recordInfo: RecordInfo) {
+
+export function apiChangeRecord(recordInfo: RecordInfo) {
     return axios.put(`/api/record`,
         recordInfo,
-        createHeaders(token)
+        createHeaders()
     );
 }
-export function apiGetHistory(token: string){
+
+export function apiGetHistory() {
     return axios.get(`/api/userdetails/history`,
-        createHeaders(token)
-    ).then(r=>r.data)
-        .then(h=>{
+        createHeaders()
+    ).then(r => r.data)
+        .then(h => {
             let locHist = [...h];
-            locHist.map(h=>{
+            locHist.map(h => {
                 h.requestTime = parseISOString(h.requestTime);
                 return h;
             })
@@ -108,10 +111,10 @@ export function apiGetHistory(token: string){
         ;
 }
 
-export function apiGetHistoryEntryById(token: string, id: string){
+export function apiGetHistoryEntryById(id: string) {
     console.log(`get: /api/history/${id}`);
     return axios.get(`/api/history/${id}`,
-        createHeaders(token)
+        createHeaders()
     ).then((response: AxiosResponse<HistoryEntryTextChoices>) => response.data);
 }
 

--- a/frontend/src/services/model.ts
+++ b/frontend/src/services/model.ts
@@ -71,7 +71,12 @@ export interface RecordInfo {
     accessibility: string
 }
 
-export interface HistoryEntry {
+export interface HistoryEntryTextDate {
+    id: string,
     text: string,
     requestTime: Date
+}
+export interface HistoryEntryTextChoices {
+    text: string,
+    choices: string[]
 }

--- a/frontend/src/services/model.ts
+++ b/frontend/src/services/model.ts
@@ -1,3 +1,4 @@
+import {AxiosError} from "axios";
 
 export interface TextSend{
     text: string
@@ -28,11 +29,11 @@ export interface TextMetadataResponse {
 export interface AuthInterface {
     username : string,
     roles : string[],
-    getToken: () => string,
     error: VoverError,
     setError: (error: VoverError)=>void,
-    logout: () => void
-    login: (token: string) => void
+    logout: () => void,
+    login: (token: string) => void,
+    defaultApiResponseChecks: (err: Error | AxiosError) => void
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
history elements are clickable, text and choices on primary page is filled then. these links can also be shared with other people

- introduce own collection for HistoryEntry and save only ids in VoverUserDetails.history
- call primary site with history id works -> text is prefilled and request automatically sent, choices taken from history if possible
- frontend refactor regarding everything with jwt token, useEffect dependencies (using some useCallbacks now), etc...
- closes #106 
- closes #102 