### PR TITLE
Batch recording many words

### DIFF
--- a/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryController.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryController.java
@@ -26,7 +26,7 @@ public class PrimaryController {
         try {
             return ResponseEntity.ok().body(primaryService.onSubmittedText(primarySubmitDTO.getText(), principal.getName()));
         } catch (MultipleSubErrorException e) {
-            return ResponseEntity.internalServerError().body(new VoverErrorDTO(e));
+            return ResponseEntity.badRequest().body(new VoverErrorDTO(e));
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(new VoverErrorDTO("Unknown error while handling your request :("));
         }

--- a/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
+++ b/backend/src/main/java/com/github/mysterix5/vover/primary/PrimaryService.java
@@ -37,6 +37,9 @@ public class PrimaryService {
     private PrimaryResponseDTO createResponses(List<String> wordList, String username) {
         wordList = wordList.stream().map(String::toLowerCase).toList();
         Set<String> appearingWordsSet = wordList.stream().filter(StringOperations::isWord).collect(Collectors.toSet());
+        if(appearingWordsSet.isEmpty()){
+            throw new MultipleSubErrorException("You didn't submit a single valid word...");
+        }
         Map<String, List<RecordDbResponseDTO>> dbWordsMap = createDbWordsMap(appearingWordsSet, username);
         List<String> defaultIds = new ArrayList<>();
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import LoginPage from "./usermanagement/LoginPage";
 import AuthProvider from "./usermanagement/AuthProvider";
 import GlobalVoverErrorDisplay from "./globalTools/GlobalVoverErrorDisplay";
 import UserPage from "./pages/userpage";
+import BatchRecord from "./pages/batchrecord/BatchRecord";
 
 const darkTheme = createTheme({
     palette: {
@@ -36,6 +37,7 @@ export default function App() {
                         <Route path="/login" element={<LoginPage/>}/>
                         <Route path="/register" element={<RegisterPage/>}/>
                         <Route path="/userpage" element={<UserPage/>}/>
+                        <Route path="/batch" element={<BatchRecord/>}/>
                     </Routes>
                     <GlobalVoverErrorDisplay/>
                 </AuthProvider>

--- a/frontend/src/pages/batchrecord/BatchRecord.tsx
+++ b/frontend/src/pages/batchrecord/BatchRecord.tsx
@@ -1,0 +1,53 @@
+import {Box, Button} from "@mui/material";
+import {useEffect} from "react";
+import {useNavigate, useSearchParams} from "react-router-dom";
+
+
+export default function BatchRecord() {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const nav = useNavigate();
+
+    function createSearchParamsFromArrayToArray(name: string, array: string[]) {
+        let returnString: string = "";
+        for(const arg of array) {
+            if(returnString){
+                returnString += `&${name}=${arg}`;
+            }else{
+                returnString += `${name}=${arg}`;
+            }
+        }
+        return returnString;
+    }
+
+    function createSearchParamsFromArrayToText(name: string, array: string[]){
+        return `${name}=${array.join("+")}`;
+    }
+
+    const wordArray = [
+        "eins",
+        "zwei",
+        "drei"
+    ]
+
+    useEffect(() => {
+        console.log(searchParams.getAll("words"));
+        searchParams.getAll("words")
+    }, [])
+
+    return (
+        <Box>
+            Batch record
+            <div>
+                {searchParams.getAll("words").map((sp)=><div>{sp}</div>)}
+            </div>
+            <div>
+                {searchParams.get("text")}
+            </div>
+            <Button onClick={()=>nav(`/batch?${createSearchParamsFromArrayToArray("words", wordArray)}&${createSearchParamsFromArrayToText("text", wordArray)}`)}>
+                click
+            </Button>
+
+        </Box>
+    )
+}

--- a/frontend/src/pages/batchrecord/BatchRecord.tsx
+++ b/frontend/src/pages/batchrecord/BatchRecord.tsx
@@ -1,53 +1,75 @@
-import {Box, Button} from "@mui/material";
-import {useEffect} from "react";
+import {Box, Grid, Typography} from "@mui/material";
+import {FormEvent, useEffect, useState} from "react";
 import {useNavigate, useSearchParams} from "react-router-dom";
+import Record from "./Record";
+import {apiSaveAudio} from "../../services/apiServices";
+import {useAuth} from "../../usermanagement/AuthProvider";
 
 
 export default function BatchRecord() {
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams] = useSearchParams();
+    const [wordArray, setWordArray] = useState<Array<string>>([]);
+    const [recordIndex, setRecordIndex] = useState<number>(0);
+
+    const [audioBlob, setAudioBlob] = useState<Blob>();
+
+    const [word, setWord] = useState("");
+    const [tag, setTag] = useState("normal");
+    const [accessibility, setAccessibility] = useState("PUBLIC");
+
+
+    const {setError, defaultApiResponseChecks} = useAuth();
 
     const nav = useNavigate();
 
-    function createSearchParamsFromArrayToArray(name: string, array: string[]) {
-        let returnString: string = "";
-        for(const arg of array) {
-            if(returnString){
-                returnString += `&${name}=${arg}`;
-            }else{
-                returnString += `${name}=${arg}`;
-            }
-        }
-        return returnString;
-    }
-
-    function createSearchParamsFromArrayToText(name: string, array: string[]){
-        return `${name}=${array.join("+")}`;
-    }
-
-    const wordArray = [
-        "eins",
-        "zwei",
-        "drei"
-    ]
-
     useEffect(() => {
-        console.log(searchParams.getAll("words"));
-        searchParams.getAll("words")
-    }, [])
+        const wordArrayTmp = Array.from(new Set<string>(searchParams.getAll("words")));
+        if (wordArrayTmp.length === 0) {
+            setError({message: "the array of words to record was empty", subMessages: []});
+            nav("/?text=" + searchParams.get("text"));
+        }
+        setWordArray(wordArrayTmp);
+        setWord(wordArrayTmp[0]);
+    }, [nav, searchParams, setError])
+
+
+    function saveAudio(event: FormEvent) {
+        event.preventDefault();
+        console.log("save audio");
+
+        apiSaveAudio(word, tag, accessibility, audioBlob!)
+            .then(() => {
+                setAudioBlob(undefined);
+                if (recordIndex < wordArray.length - 1) {
+                    setWord(wordArray[recordIndex + 1]);
+                    setRecordIndex((ri) => ri + 1);
+                } else {
+                    nav("/?text=" + searchParams.get("text"));
+                }
+            }).catch((err) => {
+            defaultApiResponseChecks(err);
+            if (err.response) {
+                setError(err.response.data);
+            }
+        });
+    }
 
     return (
         <Box>
-            Batch record
-            <div>
-                {searchParams.getAll("words").map((sp)=><div>{sp}</div>)}
-            </div>
-            <div>
-                {searchParams.get("text")}
-            </div>
-            <Button onClick={()=>nav(`/batch?${createSearchParamsFromArrayToArray("words", wordArray)}&${createSearchParamsFromArrayToText("text", wordArray)}`)}>
-                click
-            </Button>
-
+            <Grid container justifyContent={"center"}>
+                {wordArray &&
+                    wordArray.map((sp, i) =>
+                        <Grid item key={i} color={i === recordIndex ? "#d70000" : "black"} m={1}>
+                            <Typography variant={"h6"}>{sp}</Typography>
+                        </Grid>)
+                }
+            </Grid>
+            <Record word={word} setWord={setWord}
+                    tag={tag} setTag={setTag}
+                    accessibility={accessibility} setAccessibility={setAccessibility}
+                    audioBlob={audioBlob} setAudioBlob={setAudioBlob}
+                    saveAudio={saveAudio}
+            />
         </Box>
     )
 }

--- a/frontend/src/pages/batchrecord/Record.tsx
+++ b/frontend/src/pages/batchrecord/Record.tsx
@@ -1,0 +1,132 @@
+import {Recorder} from "vmsg";
+import {Box, Button, Grid, TextField, ToggleButton, ToggleButtonGroup, Typography} from "@mui/material";
+import {FormEvent, MouseEvent, useState} from "react";
+import CustomAudioPlayer from "../primary/CustomAudioPlayer";
+
+const recorder = new Recorder({
+    wasmURL: "https://unpkg.com/vmsg@0.4.0/vmsg.wasm"
+});
+
+interface RecordProps {
+    word: string,
+    setWord: (w: string) => void,
+    tag: string,
+    setTag: (t: string) => void,
+    accessibility: string,
+    setAccessibility: (acc: string) => void,
+    audioBlob: Blob | undefined,
+    setAudioBlob: (blob: Blob | undefined) => void,
+    saveAudio: (event: FormEvent) => void
+}
+
+export default function Record(props: RecordProps) {
+    const [isLoading, setIsLoading] = useState(false);
+    const [isRecording, setIsRecording] = useState(false);
+
+    const [audioLink, setAudioLink] = useState("");
+
+    const record = async () => {
+        setIsLoading(true);
+
+        if (isRecording) {
+            const blob = await recorder.stopRecording();
+            setIsLoading(false);
+            setIsRecording(false);
+            props.setAudioBlob(blob);
+            setAudioLink(URL.createObjectURL(blob));
+        } else {
+            try {
+                await recorder.initAudio();
+                await recorder.initWorker();
+                recorder.startRecording();
+                setIsLoading(false);
+                setIsRecording(true);
+            } catch (e) {
+                console.error(e);
+                setIsLoading(false);
+            }
+        }
+    };
+
+    const handleAccessibility = (
+        event: MouseEvent<HTMLElement>,
+        newAccessibility: string,
+    ) => {
+        props.setAccessibility(newAccessibility);
+    };
+
+    return (
+        <>
+            <Typography variant={"h6"} align={"center"} mb={2}>
+                Record your missing words
+            </Typography>
+            <Grid container alignContent={"center"} flexDirection={"column"}>
+                <div>
+                    {
+                        <Box component={"form"} onSubmit={props.saveAudio} sx={{mt: 1}}>
+                            <Grid item m={0.5} display={"flex"} justifyContent={"center"}>
+                                <TextField
+                                    label="Word"
+                                    variant="outlined"
+                                    value={props.word}
+                                    placeholder={"your word"}
+                                    onChange={event => props.setWord(event.target.value)}
+                                />
+                            </Grid>
+                            <Grid item m={0.5} display={"flex"} justifyContent={"center"}>
+                                    <TextField
+                                        label="Tag"
+                                        variant="outlined"
+                                        value={props.tag}
+                                        placeholder={props.tag}
+                                        onChange={event => props.setTag(event.target.value)}
+                                    />
+                            </Grid>
+                            <Grid item m={0.5} display={"flex"} justifyContent={"center"}>
+                                <ToggleButtonGroup
+                                    size={"small"}
+                                    value={props.accessibility}
+                                    exclusive
+                                    onChange={handleAccessibility}
+                                >
+                                    <ToggleButton value={"PUBLIC"}>
+                                        public
+                                    </ToggleButton>
+                                    <ToggleButton value={"FRIENDS"}>
+                                        friends
+                                    </ToggleButton>
+                                    <ToggleButton value={"PRIVATE"}>
+                                        private
+                                    </ToggleButton>
+                                </ToggleButtonGroup>
+                            </Grid>
+
+                            <Grid item display={"flex"} justifyContent={"center"} mt={3}>
+                                <Button variant="contained" disabled={isLoading} onClick={record}>
+                                    {isRecording ? "Stop" : "Record"}
+                                </Button>
+                            </Grid>
+
+                            {props.audioBlob &&
+                                <Grid item mt={1} display={"flex"} justifyContent={"center"}>
+                                    <CustomAudioPlayer
+                                        audiofile={audioLink} slider={true} download={false} autoPlay={false}/>
+                                </Grid>
+                            }
+                            {props.audioBlob &&
+                                <Grid item m={1} display={"flex"} justifyContent={"center"}>
+                                    <Button
+                                        type="submit"
+                                        variant="contained"
+                                    >
+                                        save audio to db
+                                    </Button>
+                                </Grid>
+                            }
+                        </Box>
+                    }
+                </div>
+            </Grid>
+        </>
+    )
+}

--- a/frontend/src/pages/record/index.tsx
+++ b/frontend/src/pages/record/index.tsx
@@ -110,6 +110,7 @@ export default function Record() {
                             <Grid item m={0.5}>
                                 <ToggleButtonGroup
                                     value={accessibility}
+                                    size={"small"}
                                     exclusive
                                     onChange={handleAccessibility}
                                 >


### PR DESCRIPTION
- closes #114 
- new frontend page for batch recording reachable from 'record missing words' and 'record all words' on primary page
- it handles two search params: (words: string[]) and (text: string) where words can then be one after another be recorded and text will just get sent back to the primary page after finishing the recording to keep the information about the text
- closes #99 